### PR TITLE
Grouped 8 data into a day forecast, capitalized description

### DIFF
--- a/src/components/currentWeather/current-weather.css
+++ b/src/components/currentWeather/current-weather.css
@@ -6,7 +6,7 @@
     color: #fff;
     /* background-color: #333; */
     /* background-image: linear-gradient(to bottom, #000000, #ffaf2f ); */
-    margin: 20px auto 0 auto;
+    margin: 20px auto 20px auto;
     padding: 0 20px 20px 20px;
 }
 
@@ -34,6 +34,7 @@
     font-size: 14px;
     line-height: 1;
     margin: 5px 0 0 0;
+    text-transform: capitalize;
 }
 
 .weather-icon{

--- a/src/components/forecast/forecast.css
+++ b/src/components/forecast/forecast.css
@@ -2,7 +2,9 @@
     font-size: 23px;
     font-weight: 700;
 }
-
+.label-box{
+    margin: 20px;
+}
 .daily-item{
     background-color: #eeeeee;
     border-radius: 15px;
@@ -26,10 +28,18 @@
     margin: 16px;
 }
 
+.date{
+    color:#757575;
+    margin-left: 20px;
+    font-size: 12px;
+    font-weight: 400;
+}
+
 .description{
     flex: 1 1;
     margin-right: 15px;
     text-align: right;
+    text-transform: capitalize;
 }
 
 .min-max{

--- a/src/components/forecast/forecast.js
+++ b/src/components/forecast/forecast.js
@@ -19,14 +19,18 @@ const WEEK_DAYS = [
 
 const Forecast = ({ data }) => {
   const dayInaWeek = new Date().getDay();
+  const dates = data.listOfDays;
   const forecastDays = WEEK_DAYS.slice(dayInaWeek, WEEK_DAYS.length).concat(
     WEEK_DAYS.slice(0, dayInaWeek)
   );
+
   return (
     <>
-      <label className="title"> Daily Forecast</label>
+      <div className="label-box">
+        <label className="title"> 5 Daily Forecast</label>
+      </div>
       <Accordion allowZeroExpanded>
-        {data.list.splice(0, 7).map((item, idx) => {
+        {data.listOfDates.map((item, idx) => {
           return (
             <AccordionItem key={idx}>
               <AccordionItemHeading>
@@ -35,21 +39,25 @@ const Forecast = ({ data }) => {
                     <img
                       alt="weather-img"
                       className="icon-small"
-                      src={`newIcons/${item.weather[0].icon}.png`}
+                      src={`newIcons/${dates[item].icon}.png`}
                     />
-                    <label className="day">{forecastDays[idx]}</label>
+                    <label className="day">
+                      {forecastDays[idx]}
+                      <span className="date">{item}</span>
+                    </label>
+
                     <label className="description">
-                      {item.weather[0].description}
+                      {dates[item].weather_description}
                     </label>
                     <label className="min-max">
-                      {Math.round(item.main.temp_min)}°C /{" "}
-                      {Math.round(item.main.temp_max)}°C
+                      {Math.round(dates[item].temp_min)}°C /{" "}
+                      {Math.round(dates[item].temp_max)}°C
                     </label>
                   </div>
                 </AccordionItemButton>
               </AccordionItemHeading>
               <AccordionItemPanel>
-                <div className="daily-details-grid">
+                {/* <div className="daily-details-grid">
                   <div className="daily-details-grid-item">
                     <label>Pressure</label>
                     <label>{item.main.pressure} hpa</label>
@@ -74,7 +82,7 @@ const Forecast = ({ data }) => {
                     <label>Feels like</label>
                     <label>{Math.round(item.main.feels_like)} °C</label>
                   </div>
-                </div>
+                </div>  */}
               </AccordionItemPanel>
             </AccordionItem>
           );


### PR DESCRIPTION
The API now fetches a forecast for the next 5 days, providing data with 3-hour intervals. Previously, only the first 7 items of the response were displayed, which inaccurately represented the forecast for the upcoming days. This issue has been resolved by grouping the forecast data on a daily basis, ensuring that it is displayed correctly.